### PR TITLE
Add First setup steps for the repo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,4 +10,7 @@ When implementing a new feature or fixing a bug, please create a new pull reques
 
 ## First setup
 
-**[TODO 05/01/2018 @vanessa-cooper]:** _It's been a while since anyone ran a fresh copy of this repo. I think it's worth documenting the steps needed to install and run the repo on a new machine?_
+- `git clone` the repo
+- Run `docker-compose up` to load Anythink's backend and frontend.
+- Check the backend is running and connected to the database: http://localhost:3000/api/ping
+- Create a new user to check the frontend it’s connected to the backend: http://localhost:3001/register


### PR DESCRIPTION
Tells new employees to `docker-compose up` after cloning the repo, and check the backend and frontend *locally* by creating a new user.
